### PR TITLE
Make Pix API URL configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,6 @@ RUN mvn -B package -DskipTests
 FROM eclipse-temurin:21-jre-alpine
 WORKDIR /app
 COPY --from=builder /build/app/target/mcpserver-apipix-0.0.1-SNAPSHOT.jar app.jar
+ENV PIX_BASE_URL=https://pix.example.com
 EXPOSE 8080
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Este projeto demonstra a implementação de um servidor MCP (Model Context Proto
 
 ## Como funciona
 
-O núcleo da aplicação está em `app/src/main`. A classe `McpServerApplication` inicializa o Spring Boot e registra as ferramentas disponíveis. Cada método público em `PixService` anotado com `@Tool` é exposto aos clientes via HTTP através do transport provider MVC. As chamadas ao Pix são delegadas para um endpoint externo configurado pela propriedade `pix.base-url` no `application.yml`.
+O núcleo da aplicação está em `app/src/main`. A classe `McpServerApplication` inicializa o Spring Boot e registra as ferramentas disponíveis. Cada método público em `PixService` anotado com `@Tool` é exposto aos clientes via HTTP através do transport provider MVC. As chamadas ao Pix são delegadas para um endpoint externo configurado pela propriedade `pix.base-url` (ou variável de ambiente `PIX_BASE_URL`) no `application.yml`.
 
 ## Arquitetura
 
@@ -31,6 +31,9 @@ Para rodar localmente é necessário ter Java 21 e Maven instalados. Execute os 
 mvn spring-boot:run
 ```
 
+O endereço do serviço Pix pode ser ajustado com a variável de ambiente
+`PIX_BASE_URL` (por padrão `https://pix.example.com`).
+
 É possível gerar o JAR e executá-lo manualmente:
 
 ```bash
@@ -44,5 +47,5 @@ O repositório inclui um `Dockerfile` multi-stage baseado na JRE Eclipse Temurin
 
 ```bash
 docker build -t mcpserver-apipix .
-docker run --rm -p 8080:8080 mcpserver-apipix
+docker run --rm -p 8080:8080 -e PIX_BASE_URL=https://pix.example.com mcpserver-apipix
 ```

--- a/app/src/main/java/com/example/mcpserver/PixService.java
+++ b/app/src/main/java/com/example/mcpserver/PixService.java
@@ -12,7 +12,7 @@ public class PixService {
     private final WebClient webClient;
 
     public PixService(WebClient.Builder builder,
-                      @Value("${pix.base-url:https://pix.example.com}") String baseUrl) {
+                      @Value("${pix.base-url}") String baseUrl) {
         this.webClient = builder.baseUrl(baseUrl).build();
     }
 

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -11,3 +11,6 @@ spring:
           resource: true
           prompt: true
           completion: true
+
+pix:
+  base-url: https://pix.example.com

--- a/docs/playbook-mcp-server.md
+++ b/docs/playbook-mcp-server.md
@@ -134,7 +134,8 @@ public ToolCallbackProvider pixTools(PixService service) {
 ```
 
 Configure o `pix.base-url` e as credenciais de acesso (certificados e OAuth)
-de acordo com as especificações do Bacen.
+de acordo com as especificações do Bacen. Esse valor pode ser sobrescrito
+pela variável de ambiente `PIX_BASE_URL`.
 
 ## 6. Execução
 


### PR DESCRIPTION
## Summary
- make Pix API URL configurable via property
- add default property in `application.yml`
- document `PIX_BASE_URL` environment variable
- set the default in Dockerfile

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_6861ee023674832280b2fe7f0d18600a