### PR TITLE
Fix Spring Boot version and add Spring AI BOM

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -8,13 +8,25 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.0</version>
+        <version>3.4.4</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
     <properties>
         <java.version>21</java.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.ai</groupId>
+                <artifactId>spring-ai-bom</artifactId>
+                <version>1.0.0-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
## Summary
- update parent to Spring Boot 3.4.4
- manage Spring AI dependencies via BOM

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6861eecd4764832287a2759faa34c2b0