### PR TITLE
Add Pix automatic service

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -27,6 +27,11 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/app/src/main/java/com/example/mcpserver/McpServerApplication.java
+++ b/app/src/main/java/com/example/mcpserver/McpServerApplication.java
@@ -1,13 +1,26 @@
 package com.example.mcpserver;
 
+import com.example.mcpserver.service.PixService;
+import org.springframework.ai.client.tool.ToolCallbackProvider;
+import org.springframework.ai.client.tool.method.MethodToolCallbackProvider;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class McpServerApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(McpServerApplication.class, args);
+    }
+
+    @Bean
+    public ToolCallbackProvider pixTools(PixService service) {
+        return MethodToolCallbackProvider.builder()
+                .toolObjects(service)
+                .build();
     }
 
 }

--- a/app/src/main/java/com/example/mcpserver/config/PixProperties.java
+++ b/app/src/main/java/com/example/mcpserver/config/PixProperties.java
@@ -1,0 +1,17 @@
+package com.example.mcpserver.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("pix")
+public class PixProperties {
+    /** Base URL da API Pix */
+    private String baseUrl = "https://pix.example.com";
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+}

--- a/app/src/main/java/com/example/mcpserver/service/PixService.java
+++ b/app/src/main/java/com/example/mcpserver/service/PixService.java
@@ -1,0 +1,108 @@
+package com.example.mcpserver.service;
+
+import org.springframework.ai.client.tool.Tool;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+/**
+ * Serviço que encapsula chamadas à API Pix.
+ */
+@Service
+public class PixService {
+
+    private final WebClient webClient;
+
+    public PixService(WebClient.Builder builder, @Value("${pix.base-url}") String baseUrl) {
+        this.webClient = builder.baseUrl(baseUrl).build();
+    }
+
+    @Tool(description = "Criar recorrência de pagamento")
+    public Mono<String> criarRecorrencia(String recJson) {
+        return webClient.post()
+                .uri("/rec")
+                .bodyValue(recJson)
+                .retrieve()
+                .bodyToMono(String.class);
+    }
+
+    @Tool(description = "Consultar recorrência")
+    public Mono<String> consultarRecorrencia(String idRec) {
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder.path("/rec/{idRec}").build(idRec))
+                .retrieve()
+                .bodyToMono(String.class);
+    }
+
+    @Tool(description = "Revisar recorrência")
+    public Mono<String> revisarRecorrencia(String idRec, String recJson) {
+        return webClient.patch()
+                .uri(uriBuilder -> uriBuilder.path("/rec/{idRec}").build(idRec))
+                .bodyValue(recJson)
+                .retrieve()
+                .bodyToMono(String.class);
+    }
+
+    @Tool(description = "Listar recorrências")
+    public Mono<String> listarRecorrencias(String inicio, String fim) {
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder.path("/rec")
+                        .queryParam("inicio", inicio)
+                        .queryParam("fim", fim)
+                        .build())
+                .retrieve()
+                .bodyToMono(String.class);
+    }
+
+    @Tool(description = "Criar solicitação de recorrência")
+    public Mono<String> criarSolicitacao(String solicJson) {
+        return webClient.post()
+                .uri("/solicrec")
+                .bodyValue(solicJson)
+                .retrieve()
+                .bodyToMono(String.class);
+    }
+
+    @Tool(description = "Consultar solicitação de recorrência")
+    public Mono<String> consultarSolicitacao(String idSolicRec) {
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder.path("/solicrec/{id}").build(idSolicRec))
+                .retrieve()
+                .bodyToMono(String.class);
+    }
+
+    @Tool(description = "Revisar solicitação de recorrência")
+    public Mono<String> revisarSolicitacao(String idSolicRec, String solicJson) {
+        return webClient.patch()
+                .uri(uriBuilder -> uriBuilder.path("/solicrec/{id}").build(idSolicRec))
+                .bodyValue(solicJson)
+                .retrieve()
+                .bodyToMono(String.class);
+    }
+
+    @Tool(description = "Configurar webhook de recorrências")
+    public Mono<String> configurarWebhookRec(String webhookJson) {
+        return webClient.put()
+                .uri("/webhookrec")
+                .bodyValue(webhookJson)
+                .retrieve()
+                .bodyToMono(String.class);
+    }
+
+    @Tool(description = "Consultar webhook de recorrências")
+    public Mono<String> consultarWebhookRec() {
+        return webClient.get()
+                .uri("/webhookrec")
+                .retrieve()
+                .bodyToMono(String.class);
+    }
+
+    @Tool(description = "Cancelar webhook de recorrências")
+    public Mono<Void> cancelarWebhookRec() {
+        return webClient.delete()
+                .uri("/webhookrec")
+                .retrieve()
+                .bodyToMono(Void.class);
+    }
+}

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -1,6 +1,6 @@
-logging:
-  pattern:
-    console:
 spring:
   main:
     banner-mode: off
+
+pix:
+  base-url: https://pix.example.com


### PR DESCRIPTION
## Summary
- create `PixProperties` configuration
- add `PixService` with endpoints for recorrência (Pix automático)
- register service as MCP Tool and enable configuration scanning
- add WebFlux dependency
- configure default `pix.base-url`

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686348c7de388322abda17668aff8cca